### PR TITLE
fix(resources): support for zstd compression

### DIFF
--- a/packages/resources/global.d.ts
+++ b/packages/resources/global.d.ts
@@ -1,0 +1,22 @@
+declare module 'zstd-codec' {
+  export interface ZstdCodec {
+    run(callback: (instance: ZstdInstance) => void): void;
+  }
+
+  export interface ZstdInstance {
+    Streaming: new () => ZstdStreamingCodec;
+    Simple: new () => ZstdSimpleCodec;
+  }
+
+  export interface ZstdStreamingCodec {
+    compress(input: Uint8Array, compressionLevel?: number): Uint8Array;
+    decompress(input: Uint8Array): Uint8Array;
+  }
+
+  export interface ZstdSimpleCodec {
+    compress(input: Uint8Array, compressionLevel?: number): Uint8Array;
+    decompress(input: Uint8Array): Uint8Array;
+  }
+
+  export const ZstdCodec: ZstdCodec;
+}

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -20,6 +20,9 @@
   "peerDependencies": {
     "playwright": "^1.48.1"
   },
+  "dependencies": {
+    "zstd-codec": "^0.1.5"
+  },
   "license": "MIT",
   "author": {
     "name": "Artem Yavorskyi",

--- a/packages/resources/src/decoders/zstd.ts
+++ b/packages/resources/src/decoders/zstd.ts
@@ -1,0 +1,17 @@
+import * as zstd from 'zstd-codec';
+
+// Initialize zstd decoder
+let zstdDecoder: zstd.ZstdStreamingCodec | null = null;
+// Async initialization for zstd codec
+export const initZstd = async () => {
+  if (!zstdDecoder) {
+    return new Promise<zstd.ZstdStreamingCodec>((resolve) => {
+      const ZstdCodec = zstd.ZstdCodec;
+      ZstdCodec.run((instance) => {
+        zstdDecoder = new instance.Streaming();
+        resolve(zstdDecoder);
+      });
+    });
+  }
+  return zstdDecoder;
+};

--- a/packages/resources/src/resources.ts
+++ b/packages/resources/src/resources.ts
@@ -43,12 +43,16 @@ export class Resources {
           const contentEncoding = headers['content-encoding'] || '';
           // Playwright doesn't decode zstd encoding, so we need to manually decode it.
           if (contentEncoding.includes('zstd')) {
-            const zstdDecoder = await initZstd();
-            const buffer = await response.body();
-            const uint8Array = new Uint8Array(buffer);
-            const decompressedArray = zstdDecoder.decompress(uint8Array);
-            const decoder = new TextDecoder('utf-8');
-            content = decoder.decode(decompressedArray);
+            try {
+              const zstdDecoder = await initZstd();
+              const buffer = await response.body();
+              const uint8Array = new Uint8Array(buffer);
+              const decompressedArray = zstdDecoder.decompress(uint8Array);
+              const decoder = new TextDecoder('utf-8');
+              content = decoder.decode(decompressedArray);
+            } catch (error) {
+              onError?.(error as Error);
+            }
           } else {
             content = await response.text();
           }

--- a/packages/resources/tsconfig.json
+++ b/packages/resources/tsconfig.json
@@ -13,5 +13,5 @@
     "outDir": "./build"
   },
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src", "global.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7885,3 +7885,8 @@ yocto-queue@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
   integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
+
+zstd-codec@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/zstd-codec/-/zstd-codec-0.1.5.tgz#c180193e4603ef74ddf704bcc835397d30a60e42"
+  integrity sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==


### PR DESCRIPTION
### Problem
We discovered an issue related to compressing, not supported by default by playwright.

Our detection tool received compressed code, which resulted in missing results.

This PR adds support for handling zstd (Zstandard) compressed resources in our content fetching logic. Zstandard is a high-performance compression algorithm developed by Facebook that is becoming increasingly popular on the web.


### Changes

- Created a dedicated zstd decoder module with proper TypeScript typings
- Added specialized handling for content with content-encoding: zstd header
- Implemented proper buffer-to-text conversion for decompressed content
- Extracted compression logic to a separate module for better code organization

### Implementation details

- Used the zstd-codec library to handle decompression
- Implemented async initialization pattern for the zstd decoder
- Added proper TypeScript type definitions for the zstd-codec library
- Used TextDecoder for proper UTF-8 conversion of decompressed content

Before:
<img width="1489" alt="Screenshot 2025-04-09 at 22 35 58" src="https://github.com/user-attachments/assets/632787d3-b013-4a17-8de1-e7ec5a4d3ee7" />

After:
<img width="1566" alt="Screenshot 2025-04-09 at 22 35 44" src="https://github.com/user-attachments/assets/8f058804-636b-4e4d-b535-aa0ff496695c" />
