### PR TITLE
fix: improve plausible script detection

### DIFF
--- a/packages/features/src/categories/analytics/patterns/plausible.ts
+++ b/packages/features/src/categories/analytics/patterns/plausible.ts
@@ -15,6 +15,16 @@ export const plausible = [
   },
   {
     name: 'script' as const,
+    score: 1.2,
+    scripts: [
+      /console\.warn\(['"]\[Plausible\] Ignoring event because website is running locally['"]\)/,
+      /console\.warn\(['"]\[Plausible\] Ignoring event because "plausible_ignore" is set to "true" in localStorage['"]\)/,
+      /['"]apiHost["']:\s*["']https:\/\/plausible\.io["']/,
+      /window\.localStorage\.plausible_ignore === ['"]true['"]/,
+    ],
+  },
+  {
+    name: 'scriptDataDomain' as const,
     score: 1,
     browser: async (page: Page) => {
       return page.evaluate(() => {


### PR DESCRIPTION
This PR adds more patterns for plausible detection.

We are tracking 4 additional patterns with 1.2 score.

1. console.warn('[Plausible] Ignoring event because website is running locally warn')
2. console.warn('[Plausible] Ignoring event because "plausible_ignore" is set to "true" in localStorage')
3. "apiHost": "https://plausible.io"
4. window.localStorage.plausible_ignore === "true"

URL to test and compare:
https://browsersl.ist/