### PR TITLE
fix: add hotjar meta

### DIFF
--- a/packages/features/src/categories/analytics/meta/index.ts
+++ b/packages/features/src/categories/analytics/meta/index.ts
@@ -4,6 +4,7 @@ import { countly } from './countly.js';
 import { fathom } from './fathom.js';
 import { googleAnalytics } from './google-analytics.js';
 import { heap } from './heap.js';
+import { hotjar } from './hotjar.js';
 import { matomo } from './matomo.js';
 import { mixpanel } from './mixpanel.js';
 import { plausible } from './plausible.js';
@@ -19,6 +20,7 @@ export const meta = {
   vercelAnalytics,
   posthog,
   countly,
+  hotjar,
   heap,
   clarity,
   matomo,

--- a/packages/resources/src/resources.ts
+++ b/packages/resources/src/resources.ts
@@ -116,7 +116,6 @@ export class Resources {
 
     if (content) {
       if (resource.type === 'script') {
-        console.log(resource.url, content);
         this.scriptsMap.set(resource.url, content);
         return;
       }
@@ -128,7 +127,6 @@ export class Resources {
         this.documentsMap.set(resource.url, content);
         return;
       }
-      console.warn('Unknown resource type', resource.type);
     }
   }
 


### PR DESCRIPTION
Just adding missing hotjar to meta object.

Without it, we can't find it in runtime and display logo and title normally.

Bug:
<img width="237" alt="Screenshot 2025-04-10 at 15 56 50" src="https://github.com/user-attachments/assets/3a248783-b8ea-430f-846e-6e12db56e0d1" />
<img width="802" alt="Screenshot 2025-04-10 at 15 56 48" src="https://github.com/user-attachments/assets/535aec19-ae92-43ce-95dc-95b98b0d7410" />
