### PR TITLE
fix(features): splitBee confidence

### DIFF
--- a/packages/features/src/categories/analytics/patterns/splitbee.ts
+++ b/packages/features/src/categories/analytics/patterns/splitbee.ts
@@ -27,7 +27,7 @@ export const splitbee = [
   },
   {
     name: 'cookie' as const,
-    score: 1.2,
+    score: 0.3,
     browser: async (page: Page) => {
       const cookies = await page.context().cookies();
       return cookies.some((cookie) => cookie.name.startsWith('sb_'));
@@ -35,7 +35,7 @@ export const splitbee = [
   },
   {
     name: 'storage' as const,
-    score: 1.2,
+    score: 0.3,
     browser: async (page: Page) => {
       const hasSplitBee = await page.evaluate(() => {
         for (let i = 0; i < localStorage.length; i++) {

--- a/packages/resources/src/resources.ts
+++ b/packages/resources/src/resources.ts
@@ -116,7 +116,6 @@ export class Resources {
 
     if (content) {
       if (resource.type === 'script') {
-        console.log(resource.url, content);
         this.scriptsMap.set(resource.url, content);
         return;
       }
@@ -128,7 +127,6 @@ export class Resources {
         this.documentsMap.set(resource.url, content);
         return;
       }
-      console.warn('Unknown resource type', resource.type);
     }
   }
 


### PR DESCRIPTION
Recently, I found issues with sb_ cookies and Local storage checks related to splitBee.
It seems like sb_ it's a common pattern and even google set it to google.com

As a result, we have false-positive results based on splitbee.
Since splitBee is set to globals, let's rely on it and reduce `sb_` confidence