### PR TITLE
fix: use dummy env for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Install playwright
         run: yarn playwright install --with-deps
 
+      - name: Create dummy .env file for PR from forks to complete build
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "SUPABASE_URL=dummy_value" > apps/web/.env
+          echo "SUPABASE_KEY=dummy_value" >> apps/web/.env
+          echo "SUPABASE_ID=dummy_value" >> apps/web/.env
+          echo "LOGFLARE_SOURCE_TOKEN=dummy_value" >> apps/web/.env
+          echo "LOGFLARE_API_KEY=dummy_value" >> apps/web/.env
+          echo "CLARITY_PROJECT_ID=dummy_value" >> apps/web/.env
+          echo "UNBUILT_API_KEY=dummy_value" >> apps/web/.env
+
+      # Only for push to main, run full build
       - name: Build application
         run: yarn turbo run build
 

--- a/packages/resources/src/resources.ts
+++ b/packages/resources/src/resources.ts
@@ -116,7 +116,6 @@ export class Resources {
 
     if (content) {
       if (resource.type === 'script') {
-        console.log(resource.url, content);
         this.scriptsMap.set(resource.url, content);
         return;
       }
@@ -128,7 +127,6 @@ export class Resources {
         this.documentsMap.set(resource.url, content);
         return;
       }
-      console.warn('Unknown resource type', resource.type);
     }
   }
 


### PR DESCRIPTION
Seems like all new PRs from forks are failing.
It happens due to issue related the fact, github doesn't share env variables for workflows for forks due to security concerns.

As a result, we still want to build web app to make some validations.