### PR TITLE
fix: skip pr build for next.js app since its build with vercel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,20 +43,13 @@ jobs:
       - name: Install playwright
         run: yarn playwright install --with-deps
 
-      - name: Create dummy .env file for PR from forks to complete build
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-        run: |
-          echo "SUPABASE_URL=dummy_value" > apps/web/.env
-          echo "SUPABASE_KEY=dummy_value" >> apps/web/.env
-          echo "SUPABASE_ID=dummy_value" >> apps/web/.env
-          echo "LOGFLARE_SOURCE_TOKEN=dummy_value" >> apps/web/.env
-          echo "LOGFLARE_API_KEY=dummy_value" >> apps/web/.env
-          echo "CLARITY_PROJECT_ID=dummy_value" >> apps/web/.env
-          echo "UNBUILT_API_KEY=dummy_value" >> apps/web/.env
-
-      # Only for push to main, run full build
-      - name: Build application
+      - name: Build application (main branch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: yarn turbo run build
+
+      - name: Build packages and CLI only (PR)
+        if: github.event_name == 'pull_request'
+        run: yarn turbo run build --filter="./packages/*" --filter="@unbuilt/cli"
 
       - name: Run lint
         run: yarn lint

--- a/apps/web/src/server/supabase.ts
+++ b/apps/web/src/server/supabase.ts
@@ -2,11 +2,7 @@ import { createClient } from '@supabase/supabase-js';
 import '../../envConfig';
 import { Database } from '../../supabase/database.types';
 
-if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) {
-  throw new Error('Missing Supabase environment variables');
-}
-
 export const supabase = createClient<Database>(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_KEY
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_KEY!
 );

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,6 +6,7 @@
     "incremental": true,
     "module": "ESNext",
     "target": "es6",
+    "noEmit": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "paths": {


### PR DESCRIPTION
Seems like dummy env file is not working properly, so the idea just to skip PR build for next.js since it's being executed anyway by separate task for deploy preview step.