### PR TITLE
feat: add random url generation

### DIFF
--- a/apps/web/src/actions/index.ts
+++ b/apps/web/src/actions/index.ts
@@ -15,7 +15,6 @@ import {
 import { getTechnologyWebsitesQuery } from '../server/api/get-technology-websites';
 import { getAnalysis, getStatus, startAnalysis } from './analyzer';
 import { normalizeUrl } from '@unbuilt/helpers';
-import { getRandomSuggestions } from '@/app/utils/shuffle';
 
 type AnalyzeState = { error: string | null; analysisId?: string };
 
@@ -104,20 +103,4 @@ export async function getTechnologyWebsites<T extends AnalysisTechnologies>({
     search,
     pageSize,
   });
-}
-
-export async function getSuggestionsUrls() {
-  // TODO: Use popular analysis
-  return getRandomSuggestions([
-    'nextjs.org',
-    'react.dev',
-    'vuejs.org',
-    'wix.com',
-    'vercel.com',
-    'lightest.app',
-    'unbuilt.app',
-    'mentor.sh',
-    'cal.com',
-    'nuxt.com',
-  ]);
 }

--- a/apps/web/src/actions/index.ts
+++ b/apps/web/src/actions/index.ts
@@ -15,6 +15,7 @@ import {
 import { getTechnologyWebsitesQuery } from '../server/api/get-technology-websites';
 import { getAnalysis, getStatus, startAnalysis } from './analyzer';
 import { normalizeUrl } from '@unbuilt/helpers';
+import { getRandomSuggestions } from '@/app/utils/shuffle';
 
 type AnalyzeState = { error: string | null; analysisId?: string };
 
@@ -103,4 +104,20 @@ export async function getTechnologyWebsites<T extends AnalysisTechnologies>({
     search,
     pageSize,
   });
+}
+
+export async function getSuggestionsUrls() {
+  // TODO: Use popular analysis
+  return getRandomSuggestions([
+    'nextjs.org',
+    'react.dev',
+    'vuejs.org',
+    'wix.com',
+    'vercel.com',
+    'lightest.app',
+    'unbuilt.app',
+    'mentor.sh',
+    'cal.com',
+    'nuxt.com',
+  ]);
 }

--- a/apps/web/src/app/components/url-suggestions/url-suggestions.tsx
+++ b/apps/web/src/app/components/url-suggestions/url-suggestions.tsx
@@ -1,16 +1,19 @@
 import { useAnalysisForm } from '@/app/contexts/analysis-form/use-analysis-form';
+import { getSeededRandomSuggestions } from '@/app/utils/shuffle';
 import { Button } from '@/components/ui';
 
-const urlSuggestionsList = [
+const urlSuggestionsList = getSeededRandomSuggestions([
   'nextjs.org',
   'react.dev',
   'vuejs.org',
+  'vercel.com',
+  'lightest.app',
+  'mentor.sh',
+  'unbuilt.app',
+  'cal.com',
+  'nuxt.com',
   'wix.com',
-  // 'stripe.com',
-  // 'github.com',
-  // 'shopify.com',
-  // 'nytimes.com',
-];
+]);
 
 export const URLSuggestions = ({
   onChangeUrl,

--- a/apps/web/src/app/utils/shuffle.ts
+++ b/apps/web/src/app/utils/shuffle.ts
@@ -1,6 +1,4 @@
-// utils/seeded-random.js
 export function createSeededRandom(seed: number) {
-  // Simple seeded random function
   return function () {
     seed = (seed * 9301 + 49297) % 233280;
     return seed / 233280;
@@ -17,7 +15,7 @@ export function getSeededRandomSuggestions(
   // Create a copy of the array to avoid modifying original
   const shuffled = [...items];
 
-  // Fisher-Yates shuffle with seeded random
+  // Shuffle with seeded random
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];

--- a/apps/web/src/app/utils/shuffle.ts
+++ b/apps/web/src/app/utils/shuffle.ts
@@ -1,0 +1,29 @@
+// utils/seeded-random.js
+export function createSeededRandom(seed: number) {
+  // Simple seeded random function
+  return function () {
+    seed = (seed * 9301 + 49297) % 233280;
+    return seed / 233280;
+  };
+}
+
+export function getSeededRandomSuggestions(
+  items: string[],
+  count = 4,
+  seed = getTodaysSeed()
+) {
+  const random = createSeededRandom(seed);
+
+  // Create a copy of the array to avoid modifying original
+  const shuffled = [...items];
+
+  // Fisher-Yates shuffle with seeded random
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled.slice(0, count);
+}
+
+const getTodaysSeed = () => new Date().getDate() + new Date().getMonth() * 31;


### PR DESCRIPTION
### Problem
Currently we support only 4 urls to suggest on the main page

### Solution
Implemented a seeded random approach to ensure consistent randomization between server and client rendering. The solution:

- Created a utility function that uses a deterministic seed to produce the same "random" results on both server and client
- Modified the URL suggestions component to use this seeded randomization
- Maintained the original UI and functionality while eliminating hydration mismatches

This approach allows us to display random suggestions that remain consistent throughout the page lifecycle while avoiding the "Text content did not match" React hydration errors.

### Testing

Verified no hydration warnings in the browser console
Confirmed suggestions render consistently between server and client
Tested on multiple page refreshes to ensure stability