### PR TITLE
feat: Optimize Deployment Process by Leveraging GitHub Infrastructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,21 @@ jobs:
         env:
           NODE_ENV: test
 
+      # Archive the build artifacts for deployment
+      - name: Archive build artifacts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          tar -czf build-artifacts.tar.gz apps/web/.next apps/web/public node_modules package.json yarn.lock ecosystem.config.cjs
+
+      # Upload build artifacts
+      - name: Upload build artifacts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: build-artifacts.tar.gz
+          retention-days: 1
+
   publish-cli:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -146,16 +161,25 @@ jobs:
       CLARITY_PROJECT_ID: ${{ secrets.CLARITY_PROJECT_ID }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
         with:
-          node-version: '22'
-          cache: 'yarn'
+          name: build-artifacts
 
-      - name: Deploy to DigitalOcean
+      # Prepare for artifact transfer
+
+      # Use SCP via SSH Action to transfer artifacts
+      - name: Transfer artifacts to DigitalOcean
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          source: "build-artifacts.tar.gz"
+          target: "/home/server/unbuilt-app/"
+
+      # Deploy on server
+      - name: Deploy on DigitalOcean
         uses: appleboy/ssh-action@v0.1.4
         with:
           host: ${{ secrets.DROPLET_IP }}
@@ -165,16 +189,19 @@ jobs:
           script: |
             set -e # Exit if fail
             cd /home/server/unbuilt-app && \
-            git fetch origin main && git reset --hard origin/main && \
-            echo "SUPABASE_URL=${SUPABASE_URL}" > apps/web/.env && \
-            echo "SUPABASE_KEY=${SUPABASE_KEY}" >> apps/web/.env && \
-            echo "SUPABASE_ID=${SUPABASE_ID}" >> apps/web/.env && \
-            echo "LOGFLARE_SOURCE_TOKEN=${LOGFLARE_SOURCE_TOKEN}" >> apps/web/.env && \
-            echo "LOGFLARE_API_KEY=${LOGFLARE_API_KEY}" >> apps/web/.env && \
-            echo "CLARITY_PROJECT_ID=${CLARITY_PROJECT_ID}" >> apps/web/.env && \
-            echo "UNBUILT_API_KEY=${UNBUILT_API_KEY}" >> apps/web/.env && \
-            yarn install && \
-            NODE_ENV=production yarn turbo run build && \
-            pm2 delete web || true && \
+            # Create .env file
+            echo "SUPABASE_URL=${SUPABASE_URL}" > .env && \
+            echo "SUPABASE_KEY=${SUPABASE_KEY}" >> .env && \
+            echo "SUPABASE_ID=${SUPABASE_ID}" >> .env && \
+            echo "LOGFLARE_SOURCE_TOKEN=${LOGFLARE_SOURCE_TOKEN}" >> .env && \
+            echo "LOGFLARE_API_KEY=${LOGFLARE_API_KEY}" >> .env && \
+            echo "CLARITY_PROJECT_ID=${CLARITY_PROJECT_ID}" >> .env && \
+            echo "UNBUILT_API_KEY=${UNBUILT_API_KEY}" >> .env && \
+            # Extract new build artifacts
+            tar -xzf build-artifacts.tar.gz && \
+            # Restart the application
+            NODE_ENV=production pm2 delete web || true && \
             NODE_ENV=production pm2 start ecosystem.config.cjs --update-env && \
-            pm2 save --force
+            pm2 save --force && \
+            # Clean up
+            rm -f build-artifacts.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       # Upload build artifacts
       - name: Upload build artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: build-artifacts.tar.gz
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "dev:debug": "set NODE_OPTIONS=--inspect && next dev",
     "start:debug": "NODE_OPTIONS='--inspect' next start",
-    "build": "NODE_OPTIONS='--inspect' next build",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint .",
     "pull-production-schema": "yarn env-setup --sync-schema",


### PR DESCRIPTION
### Optimize Deployment Process by Leveraging GitHub Infrastructure

#### Motivation
Our current deployment process builds the application directly on our Digital Ocean droplet, which has several disadvantages:

- Consumes server resources (CPU, memory, disk I/O) during builds
- Increases deployment time as the server has limited resources compared to GitHub runners
- Causes temporary performance degradation during deployments
- Creates dependency on server network conditions when installing packages

#### Changes
This PR modifies our CI/CD workflow to:

- Build entirely on GitHub infrastructure: All package installation, testing, and building happens on GitHub's runners
- Bundle pre-built artifacts: Creates a single archive with the built application and dependencies
- Minimal server operations: Server only extracts artifacts and restarts the service
- Fresh environment variables: Generates .env file directly on the server using GitHub secrets


Technical Implementation
The workflow now:

- Builds and tests the application on GitHub runners
- Archives only the necessary files (built app, node_modules, config files)
- Transfers only the archive to the Digital Ocean droplet
- Creates a fresh .env file on the server
- Extracts the archive and restarts the application

This approach follows best practices for CI/CD by separating the build and deployment environments, resulting in a more robust and efficient deployment process.


In the future, we'll go further and use Vercel for FE part deployment
