### PR TITLE
feat: start new analysis when url of web app is outdated

### DIFF
--- a/apps/web/src/app/components/analysis-result/cards-grid.tsx
+++ b/apps/web/src/app/components/analysis-result/cards-grid.tsx
@@ -25,6 +25,7 @@ import { StatsCard } from './cards/stats';
 import { ComingSoonCard } from './cards/coming-soon';
 import { AnalyticsCard } from './cards/analytics';
 import { MonitoringCard } from './cards/monitoring';
+import { OutdatedBadge } from './outdated-badge';
 
 const isUnknown = (name: string | undefined) => name === 'unknown';
 
@@ -182,8 +183,14 @@ export const CardsGrid: FC<{
             </BreadcrumbList>
           </Breadcrumb>
         </div>
-        <span className="text-foreground/50 mt-4 h-6">
-          {formattedDate && <>Analysis from {formattedDate}.</>}
+        <span className="text-foreground/50 mt-4 h-6 flex items-center gap-2">
+          {formattedDate && (
+            <>
+              <span className="hidden md:inline">Analysis from </span>
+              <b>{formattedDate}</b>
+            </>
+          )}
+          {result?.url && <OutdatedBadge variant="critical" url={result.url} />}
           {truncatedUrl && (
             <NewAnalysisDialog initialUrl={truncatedUrl} selectOnOpen />
           )}

--- a/apps/web/src/app/components/analysis-result/outdated-badge.tsx
+++ b/apps/web/src/app/components/analysis-result/outdated-badge.tsx
@@ -12,7 +12,6 @@ interface OutdatedBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   url: string;
   variant?: 'subtle' | 'warning' | 'critical';
-  label?: string;
 }
 
 /**

--- a/apps/web/src/app/components/analysis-result/outdated-badge.tsx
+++ b/apps/web/src/app/components/analysis-result/outdated-badge.tsx
@@ -1,0 +1,55 @@
+// components/ui/outdated-badge.tsx
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Clock } from 'lucide-react';
+import { cn } from '@/app/utils';
+import {
+  statuses,
+  useExistingAnalysisMeta,
+} from '@/app/hooks/use-existing-analysis';
+
+interface OutdatedBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  url: string;
+  variant?: 'subtle' | 'warning' | 'critical';
+  label?: string;
+}
+
+/**
+ * Outdated Badge component
+ * Displays a badge indicating that content is outdated
+ */
+export function OutdatedBadge({
+  className,
+  url,
+  variant = 'subtle',
+  ...props
+}: OutdatedBadgeProps) {
+  const variantStyles = {
+    subtle: 'bg-muted text-muted-foreground hover:bg-muted/80',
+    warning:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300 hover:bg-amber-100/80 dark:hover:bg-amber-900/80',
+    critical:
+      'bg-destructive/15 text-destructive hover:bg-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30',
+  };
+
+  const existingAnalysis = useExistingAnalysisMeta(url);
+
+  if (!url || existingAnalysis.status !== statuses.OUTDATED) {
+    return null;
+  }
+
+  return (
+    <Badge
+      className={cn(
+        'gap-1 px-2 py-1 font-medium',
+        variantStyles[variant],
+        className
+      )}
+      {...props}
+    >
+      <Clock className="h-3 w-3" />
+      Outdated
+    </Badge>
+  );
+}

--- a/apps/web/src/app/components/new-analysis-dialog.tsx
+++ b/apps/web/src/app/components/new-analysis-dialog.tsx
@@ -24,7 +24,7 @@ export function NewAnalysisDialog({
         <DialogTrigger asChild>
           <Button
             variant="link"
-            className="text-foreground/80 hover:text-foreground text-base"
+            className="text-foreground/80 hover:text-foreground text-base px-0"
           >
             <span>New Analysis</span>
             <Repeat2Icon className="h-4 w-4" />

--- a/apps/web/src/server/analysis-manager.ts
+++ b/apps/web/src/server/analysis-manager.ts
@@ -124,7 +124,11 @@ export class AnalysisManager {
   async getAnalyzysMetaByUrl(url: string) {
     try {
       const { data } = await getAnalyzysMetaByUrlQuery(url);
-      return { id: data?.id, analyzedAt: data?.analyzed_at };
+      return {
+        id: data?.id,
+        analyzedAt: data?.analyzed_at,
+        notProcessed: data?.not_processed,
+      };
     } catch (e) {
       trackError(e as Error, { url });
       return null;

--- a/apps/web/src/server/api/get-analyzis-meta-by-url.ts
+++ b/apps/web/src/server/api/get-analyzis-meta-by-url.ts
@@ -3,15 +3,33 @@ import { trackError } from '@/app/utils/error-monitoring';
 
 export async function getAnalyzysMetaByUrlQuery(url: string) {
   try {
+    // First, get the most recent record with all fields
     const { data, error } = await supabase
       .from('tech_stack_analysis')
-      .select('id, analyzed_at')
+      .select('*') // Select all fields to check for NULLs
       .eq('url', url)
       .order('analyzed_at', { ascending: false })
       .limit(1)
       .maybeSingle();
 
     if (error) throw error;
+
+    // If we have data, find which fields are NULL
+    if (data) {
+      const notProcessedFields = Object.keys(data).filter(
+        (key) => data[key as keyof typeof data] === null
+      );
+
+      // Return the original requested fields plus the null fields information
+      return {
+        data: {
+          id: data.id,
+          analyzed_at: data.analyzed_at,
+          not_processed: notProcessedFields,
+        },
+        error: null,
+      };
+    }
 
     return { data, error: null };
   } catch (error) {


### PR DESCRIPTION
### Why
We use cached analysis to get results faster. This cache is living forever. As a result, we need to show Outdated Card for categories which were added later.
Additionally, some analysis are living for months without updates. Even in our README we had a link to old analysis which displayed false postivie redux.

### How
This pull request introduces an "Outdated Badge" feature to indicate when analysis results are outdated. It includes updates to the UI, backend logic, and data fetching mechanisms to support this functionality. The most important changes are grouped into UI enhancements, backend updates, and data handling improvements.

### UI Enhancements:
* Added a new `OutdatedBadge` component to display a badge for outdated analysis results. The badge supports different visual variants (`subtle`, `warning`, `critical`) and uses the `Clock` icon for visual indication. (`apps/web/src/app/components/analysis-result/outdated-badge.tsx`, [apps/web/src/app/components/analysis-result/outdated-badge.tsxR1-R55](diffhunk://#diff-3275fd98296fbbb1e0eb67abb2858e221d79747fc8ba6a9eaa37a1fd8c37c307R1-R55))
* Updated the `CardsGrid` component to include the `OutdatedBadge` next to the analysis date if the result is outdated. (`apps/web/src/app/components/analysis-result/cards-grid.tsx`, [apps/web/src/app/components/analysis-result/cards-grid.tsxL185-R193](diffhunk://#diff-90a442547edc8650a6e4d773525a89d3a52627d7b3b75aa923080fd9e7d1cf4fL185-R193))
* Adjusted the `NewAnalysisDialog` button styling to align with the updated design. (`apps/web/src/app/components/new-analysis-dialog.tsx`, [apps/web/src/app/components/new-analysis-dialog.tsxL27-R27](diffhunk://#diff-4db281258fe4e1721e4a619b526472754b4c097552c23a4066e553102a9fa88fL27-R27))

### Backend Updates:
* Extended the `getAnalyzysMetaByUrlQuery` function to fetch all fields from the database and identify unprocessed fields, returning them in the response. (`apps/web/src/server/api/get-analyzis-meta-by-url.ts`, [apps/web/src/server/api/get-analyzis-meta-by-url.tsR6-R33](diffhunk://#diff-c33375b4a636850ad2b2aa1f4337086a151bdc937322b83e2b4d213669bf9b85R6-R33))
* Modified the `AnalysisManager` class to include the `notProcessed` field in the analysis metadata returned by the `getAnalyzysMetaByUrl` method. (`apps/web/src/server/analysis-manager.ts`, [apps/web/src/server/analysis-manager.tsL127-R131](diffhunk://#diff-7ae34afbf1a27904982831121375a871a71bf2f09a62d415919dcda6867d59d0L127-R131))

### Data Handling Improvements:
* Added an `OUTDATED` status to the `statuses` object and implemented an `isOutdated` function to determine whether an analysis result is outdated based on its age or unprocessed fields. (`apps/web/src/app/hooks/use-existing-analysis.ts`, [apps/web/src/app/hooks/use-existing-analysis.tsR13-R38](diffhunk://#diff-f65aed4afe678f4ea87ea4b84d13df0436eb00bce37ec97fb644576f28ba0936R13-R38))
* Updated the `useExistingAnalysisMeta` hook to include `notProcessed` in the analysis metadata and return an `OUTDATED` status when applicable. (`apps/web/src/app/hooks/use-existing-analysis.ts`, [[1]](diffhunk://#diff-f65aed4afe678f4ea87ea4b84d13df0436eb00bce37ec97fb644576f28ba0936L33-R57) [[2]](diffhunk://#diff-f65aed4afe678f4ea87ea4b84d13df0436eb00bce37ec97fb644576f28ba0936R91-R98)
