### PR TITLE
fix: use the correct link for the contribution guide

### DIFF
--- a/apps/web/src/app/components/analysis-result/cards/coming-soon.tsx
+++ b/apps/web/src/app/components/analysis-result/cards/coming-soon.tsx
@@ -59,7 +59,7 @@ export function ComingSoonCard({ isLoading }: { isLoading: boolean }) {
             <span>Follow updates</span>
           </a>
           <a
-            href="https://github.com/yavorsky/unbuilt.app/contribution-guide"
+            href="https://github.com/yavorsky/unbuilt.app/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-2 hover:text-indigo-500 transition-colors"


### PR DESCRIPTION
This pull request includes a minor update to the `ComingSoonCard` component. It updates the link to the contribution guide to point to the correct file path in the repository.

* [`apps/web/src/app/components/analysis-result/cards/coming-soon.tsx`](diffhunk://#diff-38d73ad21d06d6ca45ce23dcbc8d23d53d56c70761b88cf8a65a381ea23c78acL62-R62): Changed the `href` attribute in the contribution guide link to `https://github.com/yavorsky/unbuilt.app/blob/main/CONTRIBUTING.md` for accuracy.