### PR TITLE
feat: add web app url based route

### DIFF
--- a/apps/web/src/app/(routes)/analyse/[url]/page.tsx
+++ b/apps/web/src/app/(routes)/analyse/[url]/page.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+import { getAnalysisMetaByUrl } from '@/actions';
+import { startAnalysis } from '@/actions/analyzer';
+import { normalizeUrl } from '@unbuilt/helpers';
+
+interface PageProps {
+  params: {
+    url: string;
+  };
+}
+
+export default async function AnalysePage({ params }: PageProps) {
+  const decodedUrl = decodeURIComponent(params.url);
+
+  try {
+    // Normalize the URL for consistent lookups
+    const normalizedUrl = normalizeUrl(decodedUrl);
+
+    // Check if analysis exists for this URL
+    const existingAnalysis = await getAnalysisMetaByUrl(normalizedUrl);
+
+    if (existingAnalysis?.id) {
+      // Redirect to the existing analysis
+      redirect(`/analysis/${existingAnalysis.id}`);
+    }
+
+    // No existing analysis found, create a new one
+    const result = await startAnalysis(normalizedUrl, false);
+
+    if (result.analysisId) {
+      // Redirect to the new analysis
+      redirect(`/analysis/${result.analysisId}`);
+    }
+
+    // If there's an error, redirect to home with error message
+    redirect(
+      `/?error=${encodeURIComponent(result.error || 'Failed to start analysis')}`
+    );
+  } catch (error) {
+    console.error('Error in analyse route:', error);
+    redirect(`/?error=${encodeURIComponent('Invalid URL or analysis failed')}`);
+  }
+}

--- a/apps/web/src/app/(routes)/analyse/page.tsx
+++ b/apps/web/src/app/(routes)/analyse/page.tsx
@@ -1,0 +1,48 @@
+import { redirect } from 'next/navigation';
+import { getAnalysisMetaByUrl } from '@/actions';
+import { startAnalysis } from '@/actions/analyzer';
+import { normalizeUrl } from '@unbuilt/helpers';
+
+interface PageProps {
+  searchParams: {
+    url?: string;
+  };
+}
+
+export default async function AnalysePage({ searchParams }: PageProps) {
+  const url = searchParams.url;
+
+  if (!url) {
+    // No URL provided, redirect to home
+    redirect('/');
+  }
+
+  try {
+    // Normalize the URL for consistent lookups
+    const normalizedUrl = normalizeUrl(url);
+
+    // Check if analysis exists for this URL
+    const existingAnalysis = await getAnalysisMetaByUrl(normalizedUrl);
+
+    if (existingAnalysis?.id) {
+      // Redirect to the existing analysis
+      redirect(`/analysis/${existingAnalysis.id}`);
+    }
+
+    // No existing analysis found, create a new one
+    const result = await startAnalysis(normalizedUrl, false);
+
+    if (result.analysisId) {
+      // Redirect to the new analysis
+      redirect(`/analysis/${result.analysisId}`);
+    }
+
+    // If there's an error, redirect to home with error message
+    redirect(
+      `/?error=${encodeURIComponent(result.error || 'Failed to start analysis')}`
+    );
+  } catch (error) {
+    console.error('Error in analyse route:', error);
+    redirect(`/?error=${encodeURIComponent('Invalid URL or analysis failed')}`);
+  }
+}


### PR DESCRIPTION
This pull request introduces two new route handlers for the `analyse` feature in the web application. The handlers streamline the process of analyzing URLs by normalizing them, checking for existing analyses, and redirecting users based on the analysis state.

### New route handlers for `analyse` feature:

**Dynamic route handling:**
* `apps/web/src/app/(routes)/analyse/[url]/page.tsx`: Implements a route handler that processes a URL passed as a dynamic route parameter (`params.url`). It normalizes the URL, checks for existing analysis, starts a new analysis if necessary, and redirects the user accordingly. ([apps/web/src/app/(routes)/analyse/[url]/page.tsxR1-R43](diffhunk://#diff-ac84f6a2d023231e3b122aa71e76c36c6dd039742c251ca3e1b37e73f930b2bfR1-R43))

**Query parameter-based route handling:**
* [`apps/web/src/app/(routes)/analyse/page.tsx`](diffhunk://#diff-64952464fc911d9af3ab1d3cd1caa6c1fc240c0753d7c27f8e0393111a6b4e77R1-R48): Implements a route handler that processes a URL passed as a query parameter (`searchParams.url`). Similar to the dynamic route handler, it normalizes the URL, checks for existing analysis, starts a new analysis if necessary, and redirects the user accordingly.

Addresses #37.